### PR TITLE
[Bug#40] 댓글 형식 수정

### DIFF
--- a/app/src/main/java/com/example/bangga_bangga/ViewPostActivity.kt
+++ b/app/src/main/java/com/example/bangga_bangga/ViewPostActivity.kt
@@ -12,7 +12,6 @@ import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
 import com.example.bangga_bangga.api.CommentApi
-import com.example.bangga_bangga.api.CommentRequest
 import com.example.bangga_bangga.api.ViewPostApi
 import com.example.bangga_bangga.api.LikeApi
 import com.example.bangga_bangga.model.CommentModel
@@ -69,7 +68,7 @@ class ViewPostActivity : AppCompatActivity() {
         commentSendBtn.setOnClickListener {
             commentField = findViewById(R.id.comment_field)
             if (commentField.text.isNotEmpty()) {
-                writeComment(postId, CommentRequest(commentField.text.toString()))
+                writeComment(postId, commentField.text.toString())
                 commentField.text.clear()
 
                 recreate()
@@ -118,7 +117,7 @@ class ViewPostActivity : AppCompatActivity() {
         }
     }
 
-    private fun writeComment(postId: Int, content: CommentRequest) {
+    private fun writeComment(postId: Int, content: String) {
         GlobalScope.launch(Dispatchers.Main) {
             try {
                 val commentService = CommentApi.create(this@ViewPostActivity)
@@ -168,7 +167,7 @@ class ViewPostActivity : AppCompatActivity() {
 
                 commentNickname.text = comment.nickname
                 commentCreateAt.text = comment.createdAt
-                commentContent.text = comment.content.toString()
+                commentContent.text = comment.content.substring(1, comment.content.length -1)
 
                 commentContainer.addView(commentView)
 

--- a/app/src/main/java/com/example/bangga_bangga/api/CommentApi.kt
+++ b/app/src/main/java/com/example/bangga_bangga/api/CommentApi.kt
@@ -18,7 +18,7 @@ interface CommentApi {
     @POST("/posts/{id}/comments")
     suspend fun comment(
         @Path("id") id: Int,
-        @Body request: CommentRequest
+        @Body content: String
     ): Response<CommentModel>
 
     companion object {
@@ -49,7 +49,3 @@ interface CommentApi {
 
 
 }
-
-data class CommentRequest(
-    @SerializedName("content") val content: String,
-)


### PR DESCRIPTION
content POST시 객체가 아닌 String으로 요청
댓글 출력 시 맨 앞, 맨 뒤 문자열 삭제해서 출력

issues : #40